### PR TITLE
Update build.sh: Remove "-e" from shebang 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 if [ ! -e build.sh ]; then
   echo "build.sh must be ran from the root of the project."


### PR DESCRIPTION
The "bash -e" prevents the error messages to appear. For example 
if "which cmake" fails the "echo" will not be called.
